### PR TITLE
Add Qt Py SAMD21 pins to the hardware config

### DIFF
--- a/ercf_hardware.cfg
+++ b/ercf_hardware.cfg
@@ -2,13 +2,21 @@
 
 # This config sample assume you set the two J6 jumpers on 1-2 and 4-5, i.e. [..].[..]
 
+# The default pins are for the XIAO. If using a Qt Py SAMD21, replace with the commented Qt Py pins.
+
 [mcu ercf]
 serial: /dev/serial/by-id/usb-Klipper_samd21g18a_B2D7B2694C57535020312E34221E01FF-if00
 
 # Carrot Feeder 5mm D-cut shaft
 [manual_stepper gear_stepper]
+# XIAO: PA4
+# Qt Py: PA3
 step_pin: ercf:PA4
+# XIAO: PA10
+# Qt Py: PA4
 dir_pin: ercf:PA10
+# XIAO: PA2
+# Qt Py: PA2
 enable_pin: !ercf:PA2
 rotation_distance: 22.6789511	#Bondtech 5mm Drive Gears
 gear_ratio: 80:20
@@ -16,6 +24,8 @@ microsteps: 16
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 velocity: 35
 accel: 150
+# XIAO: PA7
+# Qt Py: PA11
 endstop_pin: ^ercf:PA7
 
 [tmc2209 manual_stepper gear_stepper]
@@ -24,6 +34,8 @@ endstop_pin: ^ercf:PA7
 # Please adapt those values to the motor you are using
 # Example : for NEMA17 motors, you'll usually set the stealthchop_threshold to 0
 # and use higher current
+# XIAO: PA8
+# Qt Py: PA16
 uart_pin: ercf:PA8
 uart_address: 0
 interpolate: True
@@ -34,17 +46,27 @@ stealthchop_threshold: 500
 
 # Carrot Feeder selector
 [manual_stepper selector_stepper]
+# XIAO: PA9
+# Qt Py: PA17
 step_pin: ercf:PA9
+# XIAO: PB8
+# Qt Py: PA6
 dir_pin: ercf:PB8
+# XIAO: PA11
+# Qt Py: PA5
 enable_pin: !ercf:PA11        
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 velocity: 200
 accel: 600
+# XIAO: PB9
+# Qt Py: PA7
 endstop_pin: ^!ercf:PB9
 
 [tmc2209 manual_stepper selector_stepper]
+# XIAO: PA8
+# Qt Py: PA16
 uart_pin: ercf:PA8
 uart_address: 1
 run_current: 0.55
@@ -54,17 +76,23 @@ stealthchop_threshold: 5000
 
 # Values are for the MG90S servo
 [servo ercf_servo]
+# XIAO: PA5
+# Qt Py: PA9
 pin: ercf:PA5
 maximum_servo_angle: 180
 minimum_pulse_width: 0.00085
 maximum_pulse_width: 0.00215
 
 [duplicate_pin_override]
+# XIAO: PA6
+# Qt Py: PA10
 pins: ercf:PA6
 # Put there the pin used by the encoder and the filament_motion_sensor
 # It has to be the same pin for those 3
 
 [filament_motion_sensor encoder_sensor]
+# XIAO: PA6
+# Qt Py: PA10
 switch_pin: ^ercf:PA6
 pause_on_runout: False
 detection_length: 4.0
@@ -75,3 +103,7 @@ extruder: extruder
 pause_on_runout: False
 # filament sensor wired to the printer MCU
 switch_pin: ^P1.27
+
+# If using a Qt Py, the onboard LED can be configured as a Neopixel
+# [neopixel ercf]
+# pin: ercf:PA18


### PR DESCRIPTION
These pins are known good in my config.

The RP2040 version of the Qt Py is untested and probably has a different pinout (https://learn.adafruit.com/assets/107201).