### PR TITLE
Add Qt Py SAMD21 config

### DIFF
--- a/config/Adafruit QT Py - SAMD21E18/ercf_hardware.cfg
+++ b/config/Adafruit QT Py - SAMD21E18/ercf_hardware.cfg
@@ -51,7 +51,6 @@ endstop_pin: ^!ercf:PA7
 #endstop_pin: tmc2209_selector_stepper:virtual_endstop
 
 [tmc2209 manual_stepper selector_stepper]
-# LDO 42STH20-1004ASH(VRN)
 uart_pin: ercf:PA16
 uart_address: 1
 run_current: 0.55

--- a/config/Adafruit QT Py - SAMD21E18/ercf_hardware.cfg
+++ b/config/Adafruit QT Py - SAMD21E18/ercf_hardware.cfg
@@ -1,0 +1,91 @@
+## Enraged Rabbit : Carrot Feeder config file for ERCF EASY BRD v1.1
+
+# This file contains common pin mappings for the Adafruit Qt Py (SAMD21 version).
+# To use this config, the firmware should be compiled for the
+# SAMD21E18 with "Internal clock" and a "8KiB bootloader".
+
+# This config sample assume you set the two J6 jumpers on 1-2 and 4-5, i.e. [..].[..]
+
+[mcu ercf]
+serial: /dev/serial/by-id/usb-Klipper_samd21g18a_B75E8EA94C51535020312E372C1F18FF-if00
+
+# Carrot Feeder 5mm D-cut shaft
+[manual_stepper gear_stepper]
+step_pin: ercf:PA3
+dir_pin: ercf:PA4
+enable_pin: !ercf:PA2
+rotation_distance: 22.6789511	# Bondtech 5mm Drive Gears
+gear_ratio: 80:20
+microsteps: 16                  # Please do not go higher than 16, this can cause 'MCU Timer too close' issues under Klipper
+full_steps_per_rotation: 200    # 200 for 1.8 degree, 400 for 0.9 degree
+velocity: 35
+accel: 150
+# Right now no pin is used for the endstop, but we need to define one for klipper. So just use a random, not used pin
+endstop_pin: ^ercf:PA1          # unused pin on the Qt Py
+
+[tmc2209 manual_stepper gear_stepper]
+# Adapt accordingly to your setup and desires
+# The default values are tested with the BOM NEMA14 motor
+# Please adapt those values to the motor you are using
+# Example : for NEMA17 motors, you'll usually set the stealthchop_threshold to 0
+# and use higher current
+uart_pin: ercf:PA16
+uart_address: 0
+interpolate: True
+run_current: 0.4
+hold_current: 0.1
+sense_resistor: 0.110
+stealthchop_threshold: 500
+
+# Carrot Feeder selector
+[manual_stepper selector_stepper]
+step_pin: ercf:PA17
+dir_pin: !ercf:PA6
+enable_pin: !ercf:PA5    
+rotation_distance: 40
+microsteps: 16                  # Please do not go higher than 16, this can cause 'MCU Timer too close' issues under Klipper
+full_steps_per_rotation: 200	  # 200 for 1.8 degree, 400 for 0.9 degree
+velocity: 200
+accel: 600
+endstop_pin: ^!ercf:PA7
+#endstop_pin: tmc2209_selector_stepper:virtual_endstop
+
+[tmc2209 manual_stepper selector_stepper]
+# LDO 42STH20-1004ASH(VRN)
+uart_pin: ercf:PA16
+uart_address: 1
+run_current: 0.55
+interpolate: True
+sense_resistor: 0.110
+stealthchop_threshold: 5000
+# Uncomment the lines below if you want to use sensorless homing for the selector
+#diag_pin: ^ercf:PA11           # Set to MCU pin connected to TMC DIAG pin - move the jumper to position 2-3
+#driver_SGTHRS: 75              # 255 is most sensitive value, 0 is least sensitive
+
+# Values are for the MG90S servo
+[servo ercf_servo]
+pin: ercf:PA9
+maximum_servo_angle: 180
+minimum_pulse_width: 0.00085
+maximum_pulse_width: 0.00215
+
+[duplicate_pin_override]
+pins: ercf:PA10
+# Put there the pin used by the encoder and the filament_motion_sensor
+# It has to be the same pin for those 3
+
+[filament_motion_sensor encoder_sensor]
+switch_pin: ^ercf:PA10
+pause_on_runout: False
+detection_length: 10.0
+extruder: extruder
+# runout_gcode: _ERCF_ENCODER_MOTION_ISSUE
+
+[filament_switch_sensor toolhead_sensor]
+pause_on_runout: False
+# filament sensor wired to the printer MCU
+switch_pin: ^P1.27
+
+# Uncomment the lines below if you want to use the Qt Py LED as a Neopixel
+#[neopixel ercf]
+#pin: ercf:PA18


### PR DESCRIPTION
These pins are known good in my config, though I haven't tested the diag pin for sensorless homing.

I used these references and cross-checked them with the Kicad files:
- https://www.sigmdel.ca/michel/ha/xiao/seeeduino_xiao_01_en.html
- https://www.electroseed.fr/docs/QTPySamD21/Adafruit_QT_Py_SAMD21_pinout.pdf